### PR TITLE
ComboBox Choice of Panning Algorithm

### DIFF
--- a/AdvancedAudioProcessingCoursework/Source/PluginEditor.cpp
+++ b/AdvancedAudioProcessingCoursework/Source/PluginEditor.cpp
@@ -47,7 +47,23 @@ AdvancedAudioProcessingCourseworkAudioProcessorEditor::AdvancedAudioProcessingCo
     //***As such it can contain grabage and therefore triggers REAPER automute (channel gain is garbage).
     //***Adding this in constructor seems to have fixed the bug.
     processor.StereoPanPosition = 0;
+
+    comboBoxStereoPanningAlgorithm.reset (new ComboBox ("new combo box"));
+    addAndMakeVisible (comboBoxStereoPanningAlgorithm.get());
+    comboBoxStereoPanningAlgorithm->setEditableText (false);
+    comboBoxStereoPanningAlgorithm->setJustificationType (Justification::centredLeft);
+    comboBoxStereoPanningAlgorithm->setTextWhenNothingSelected (TRANS("Linear"));
+    comboBoxStereoPanningAlgorithm->setTextWhenNoChoicesAvailable (TRANS("(no choices)"));
+    comboBoxStereoPanningAlgorithm->addItem (TRANS("Linear"), 1);
+    comboBoxStereoPanningAlgorithm->addItem (TRANS("Equal Power"), 2);
+    comboBoxStereoPanningAlgorithm->addListener (this);
+
+    comboBoxStereoPanningAlgorithm->setBounds (184, 80, 150, 24);
     
+    //Set default choice index for panning algorithm
+    processor.AlgoChoiceIndex = 0;
+
+
     //[UserPreSize]
     //[/UserPreSize]
 
@@ -64,6 +80,7 @@ AdvancedAudioProcessingCourseworkAudioProcessorEditor::~AdvancedAudioProcessingC
     //[/Destructor_pre]
 
     sliderStereoPanPosition = nullptr;
+    comboBoxStereoPanningAlgorithm = nullptr;
 
 
     //[Destructor]. You can add your own custom destruction code here..
@@ -77,6 +94,18 @@ void AdvancedAudioProcessingCourseworkAudioProcessorEditor::paint (Graphics& g)
     //[/UserPrePaint]
 
     g.fillAll (Colour (0xff323e44));
+
+    {
+        int x = 156, y = 36, width = 200, height = 30;
+        String text (TRANS("Panning Algorithm"));
+        Colour fillColour = Colours::black;
+        //[UserPaintCustomArguments] Customize the painting arguments here..
+        //[/UserPaintCustomArguments]
+        g.setColour (fillColour);
+        g.setFont (Font (15.0f, Font::plain).withTypefaceStyle ("Regular"));
+        g.drawText (text, x, y, width, height,
+                    Justification::centred, true);
+    }
 
     //[UserPaint] Add your own custom painting code here..
     //[/UserPaint]
@@ -110,6 +139,25 @@ void AdvancedAudioProcessingCourseworkAudioProcessorEditor::sliderValueChanged (
     //[/UsersliderValueChanged_Post]
 }
 
+void AdvancedAudioProcessingCourseworkAudioProcessorEditor::comboBoxChanged (ComboBox* comboBoxThatHasChanged)
+{
+    //[UsercomboBoxChanged_Pre]
+    //[/UsercomboBoxChanged_Pre]
+
+    if (comboBoxThatHasChanged == comboBoxStereoPanningAlgorithm.get())
+    {
+        //[UserComboBoxCode_comboBoxStereoPanningAlgorithm] -- add your combo box handling code here..
+
+        //When combo box selection is changed store index in int AlgoChoiceIndex
+        processor.AlgoChoiceIndex = comboBoxStereoPanningAlgorithm->getSelectedItemIndex();
+
+        //[/UserComboBoxCode_comboBoxStereoPanningAlgorithm]
+    }
+
+    //[UsercomboBoxChanged_Post]
+    //[/UsercomboBoxChanged_Post]
+}
+
 
 
 //[MiscUserCode] You can add your own definitions of your custom methods or any other code here...
@@ -131,12 +179,20 @@ BEGIN_JUCER_METADATA
                  variableInitialisers="AudioProcessorEditor(p), processor(p)"
                  snapPixels="8" snapActive="1" snapShown="1" overlayOpacity="0.33"
                  fixedSize="0" initialWidth="600" initialHeight="400">
-  <BACKGROUND backgroundColour="ff323e44"/>
+  <BACKGROUND backgroundColour="ff323e44">
+    <TEXT pos="156 36 200 30" fill="solid: ff000000" hasStroke="0" text="Panning Algorithm"
+          fontname="Default font" fontsize="15.0" kerning="0.0" bold="0"
+          italic="0" justification="36"/>
+  </BACKGROUND>
   <SLIDER name="new slider" id="9149587c35e9c167" memberName="sliderStereoPanPosition"
           virtualName="" explicitFocusOrder="0" pos="24 24 128 144" min="-1.0"
           max="1.0" int="0.0" style="Rotary" textBoxPos="TextBoxBelow"
           textBoxEditable="1" textBoxWidth="80" textBoxHeight="20" skewFactor="1.0"
           needsCallback="1"/>
+  <COMBOBOX name="new combo box" id="cf755da7e47243ed" memberName="comboBoxStereoPanningAlgorithm"
+            virtualName="" explicitFocusOrder="0" pos="184 80 150 24" editable="0"
+            layout="33" items="Linear&#10;Equal Power" textWhenNonSelected="Linear"
+            textWhenNoItems="(no choices)"/>
 </JUCER_COMPONENT>
 
 END_JUCER_METADATA

--- a/AdvancedAudioProcessingCoursework/Source/PluginEditor.h
+++ b/AdvancedAudioProcessingCoursework/Source/PluginEditor.h
@@ -38,7 +38,8 @@
                                                                     //[/Comments]
 */
 class AdvancedAudioProcessingCourseworkAudioProcessorEditor  : public AudioProcessorEditor,
-                                                               public Slider::Listener
+                                                               public Slider::Listener,
+                                                               public ComboBox::Listener
 {
 public:
     //==============================================================================
@@ -52,6 +53,7 @@ public:
     void paint (Graphics& g) override;
     void resized() override;
     void sliderValueChanged (Slider* sliderThatWasMoved) override;
+    void comboBoxChanged (ComboBox* comboBoxThatHasChanged) override;
 
 
 
@@ -65,6 +67,7 @@ private:
 
     //==============================================================================
     std::unique_ptr<Slider> sliderStereoPanPosition;
+    std::unique_ptr<ComboBox> comboBoxStereoPanningAlgorithm;
 
 
     //==============================================================================

--- a/AdvancedAudioProcessingCoursework/Source/PluginProcessor.cpp
+++ b/AdvancedAudioProcessingCoursework/Source/PluginProcessor.cpp
@@ -156,7 +156,8 @@ void AdvancedAudioProcessingCourseworkAudioProcessor::processBlock (AudioBuffer<
     //This prevents recalculating the constants for each sample, and therefore decreases processing load.
     
     //Calculate pdash for stereo panning
-    float pDashStereo = (StereoPanPosition + 1.0) / 2.0;
+    float pDashStereoLinear = (StereoPanPosition + 1.0) / 2.0;
+    float pDashStereoConstant = (3.14159265359 * (StereoPanPosition + 1))/4;
     
     for (int channel = 0; channel < totalNumInputChannels; ++channel)
     {
@@ -166,13 +167,27 @@ void AdvancedAudioProcessingCourseworkAudioProcessor::processBlock (AudioBuffer<
         
         for (int i = 0; i < buffer.getNumSamples(); i++)
         {
-            if (channel == 0) // Left channel
+            if (AlgoChoiceIndex==0)//Linear Panning
             {
-                channelData[i] = channelData[i] * (1.0 - pDashStereo);
+                if (channel == 0) // Left channel
+                {
+                    channelData[i] = channelData[i] * (1.0 - pDashStereoLinear);
+                }
+                else // Right channel (or any other channel)
+                {
+                channelData[i] = channelData[i] * pDashStereoLinear;
+                }
             }
-            else // Right channel (or any other channel)
+            else if(AlgoChoiceIndex==1)//Constant Power
             {
-                channelData[i] = channelData[i] * pDashStereo;
+                if (channel == 0) // Left channel
+                {
+                    channelData[i] = channelData[i] * cos(pDashStereoConstant);
+                }
+                else // Right channel (or any other channel)
+                {
+                channelData[i] = channelData[i] * sin(pDashStereoConstant);
+                }
             }
         }
 

--- a/AdvancedAudioProcessingCoursework/Source/PluginProcessor.h
+++ b/AdvancedAudioProcessingCoursework/Source/PluginProcessor.h
@@ -57,6 +57,9 @@ public:
     
     //Declare float to store stereo pan position
     float StereoPanPosition;
+    
+    //Declare Integer to store Index for StereoPanningAlgorithm ComboBox Choice
+	int AlgoChoiceIndex;
 
 private:
     //==============================================================================


### PR DESCRIPTION
Note***
Plugin Editor .cpp seems to delete initialisation items (


//***A clipping is apparent when we load in REAPER and automute applied if the pan slider is untouched.
    //***This happens because StereoPanPosition float does not have a startup value.
    //***As such it can contain grabage and therefore triggers REAPER automute (channel gain is garbage).
    //***Adding this in constructor seems to have fixed the bug.
    processor.StereoPanPosition = 0;

//Set default choice index for panning algorithm
    processor.AlgoChoiceIndex = 0;

)

This seems to happen whenever PluginEditor is changed, possibly due to GUI approach used.

ComboBox selects between linear and constant power. No clipping errors on start up.

Ready to Merge

Additions are:
comboBoxStereoPanningAlgorithm
int AlgoChoiceIndex

pDashStereo is now pDashStereoLinear and new float

pDashStereoConstant also created defining constant power panning law